### PR TITLE
STOP creating directories named $ in the current directory

### DIFF
--- a/get_ros_stuff.sh
+++ b/get_ros_stuff.sh
@@ -14,8 +14,6 @@ cmd_exists git || die 'git was not found'
 
 prefix=$(cd $1 && pwd)
 
-mkdir -p $
-
 [ "$CMAKE_PREFIX_PATH" = "" ] && die 'could not find target basedir. Have you run build_catkin.sh and sourced setup.bash?'
 
 #cd $CMAKE_PREFIX_PATH


### PR DESCRIPTION
I was wondering which file sourced by my .bashrc as was recently broken, but wound up finding what was creating directories named '$' in various places on a few of my linux boxes.

It turns out that grepping for a shell script that's creating directories named $ is surprisingly difficult. B-)
