### PR TITLE
Exit bash scripts if any command fails

### DIFF
--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/build_cpp_isolated.sh
+++ b/build_cpp_isolated.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/utils.sh
 

--- a/build_eigen.sh
+++ b/build_eigen.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
- 
+
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh
- 
+
 if [ $# != 1 ] || [ $1 == '-h' ] || [ $1 == '--help' ]; then
     echo "Usage: $0 boost_source_dir"
     echo "  example: $0 /home/user/my_workspace/poco-1.4.6p2"

--- a/build_library.sh
+++ b/build_library.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/build_library_with_toolchain.sh
+++ b/build_library_with_toolchain.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/copy_boost.sh
+++ b/copy_boost.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/create_android_mk.sh
+++ b/create_android_mk.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/do_docker.sh
+++ b/do_docker.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Abort script on any failures
+set -e
 
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/utils.sh

--- a/do_everything.sh
+++ b/do_everything.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 # Define the number of simultaneous jobs to trigger for the different
 # tasks that allow it. Use the number of available processors in the
 # system.

--- a/get_library.sh
+++ b/get_library.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh

--- a/get_ros_stuff.sh
+++ b/get_ros_stuff.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh
@@ -30,5 +33,3 @@ if [ -f src/.rosinstall ]; then
 else
   wstool init -j$PARALLEL_JOBS src $my_loc/ndk.rosinstall
 fi
-
-exit 0

--- a/setup_ndk_project.sh
+++ b/setup_ndk_project.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Abort script on any failures
+set -e
+
 my_loc="$(cd "$(dirname $0)" && pwd)"
 source $my_loc/config.sh
 source $my_loc/utils.sh


### PR DESCRIPTION
Currently, our scripts runs every command, even if the previous failed, making it difficult to debug sometime, since we have to go through the massive logs.

In this PR, I've used the `set -e` which kills the script if a single command on it fails.

cc: @ernestmc @adamantivm 