### PR TITLE
Upgrade NDK to the version 9d

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,11 +1,10 @@
 system=$(uname -s | tr 'DL' 'dl')-$(uname -m)
 gcc_version=4.6
 toolchain=arm-linux-androideabi-$gcc_version
-platform=android-14
+platform=android-16
 PYTHONPATH=/opt/ros/indigo/lib/python2.7/dist-packages:$PYTHONPATH
 # Enable this value for debug build
 CMAKE_BUILD_TYPE=Debug
 # Enable this if you need to use pluginlib in Android.
 # The plugins will be statically linked
 use_pluginlib=1
-

--- a/create_android_mk.sh
+++ b/create_android_mk.sh
@@ -25,14 +25,14 @@ rm -rf $CMAKE_PREFIX_PATH/find_libs
 mkdir -p $CMAKE_PREFIX_PATH/find_libs
 cp $my_loc/files/FindLibrariesCMakeLists.txt $CMAKE_PREFIX_PATH/find_libs/CMakeLists.txt
 cd $CMAKE_PREFIX_PATH/find_libs
-cmake ../find_libs -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$ANDROID_NDK/platforms/android-14/arch-arm/usr/lib" \
+cmake ../find_libs -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$ANDROID_NDK/platforms/android-16/arch-arm/usr/lib" \
              -DALL_PACKAGES="$package_list"
 
 # Read the output file to get the paths of all of the libraries
 full_library_list=$(cat $CMAKE_PREFIX_PATH/find_libs/libraries.txt)
 
 # Parse this libraries (separated by ;), skip all libraries that start with the second argument paths (separated by ;)
-lib_output=$($my_loc/parse_libs.py $full_library_list $ANDROID_NDK/platforms/android-14/arch-arm/usr/lib)
+lib_output=$($my_loc/parse_libs.py $full_library_list $ANDROID_NDK/platforms/android-16/arch-arm/usr/lib)
 
 # Go to the output library directory
 if [ ! -d $2 ]; then
@@ -50,4 +50,3 @@ if [ $use_pluginlib -ne 0 ]; then
 else
   cat $my_loc/files/tfa/Android.mk.in2 >> ./Android.mk
 fi
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,11 @@ RUN wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | s
 RUN apt-get update && apt-get install --no-install-recommends -y ros-indigo-ros-base python-wstool
 
 # Install Android NDK
-RUN wget http://dl.google.com/android/ndk/android-ndk-r8e-linux-x86_64.tar.bz2
-RUN tar -jxvf android-ndk-r8e-linux-x86_64.tar.bz2 -C /opt
+RUN wget http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86_64.tar.bz2
+RUN tar -jxvf android-ndk-r9d-linux-x86_64.tar.bz2 -C /opt
 
 # Set-up environment
-ENV ANDROID_NDK /opt/android-ndk-r8e
+ENV ANDROID_NDK /opt/android-ndk-r9d
 
 # Install g++ to avoid "CMAKE_CXX_COMPILER-NOTFOUND was not found." error
 RUN apt-get update && apt-get install -y g++ cmake make

--- a/files/move_base_app/jni/Application.mk
+++ b/files/move_base_app/jni/Application.mk
@@ -1,4 +1,4 @@
 #NDK_TOOLCHAIN_VERSION=4.4.3
 APP_STL := gnustl_static
-APP_PLATFORM := android-14
+APP_PLATFORM := android-16
 APP_ABI := armeabi-v7a

--- a/files/sample_app/jni/Application.mk
+++ b/files/sample_app/jni/Application.mk
@@ -1,4 +1,4 @@
 #NDK_TOOLCHAIN_VERSION=4.4.3
 APP_STL := gnustl_static
-APP_PLATFORM := android-14
+APP_PLATFORM := android-16
 APP_ABI := armeabi-v7a


### PR DESCRIPTION
We can do upgrade of NDK up to the 9d with minimal changes. It brings users more modern
available platforms from android-9 up to android-19. Before they could choose
only android-14 as maximum platform.

The update of the default target version is proposed from android-14 to android-16
as the latest creates "position independent executables (PIE)" by default. It's not possible
to run not PIE on platforms >= android-16. It seems to be more logical to switch default
to support modern android android-16 to android-25 than supporting the previous versions.

It's still possible for user to compile to older versions, down to android-9. He just has
to manually switch the target version.